### PR TITLE
Fix syntax issues in Python files

### DIFF
--- a/sqlrustler/__init__.py
+++ b/sqlrustler/__init__.py
@@ -5,7 +5,7 @@ from .expressions import ExpressionHandler
 from .F import F
 from .Q import Q
 from .window import Window
-from .field import Field, ForeignKeyField, IntegerField, CharField, TextField, DateTimeField, BooleanField, JSONField, ArrayField, DecimalField, DateField,FloatField
+from .field import Field, ForeignKeyField, IntegerField, CharField, TextField, DateTimeField, BooleanField, JSONField, ArrayField, DecimalField, DateField, FloatField
 from .model import Model
 from .sqlrustler import DatabaseConfig, Session, DatabaseConnection
 

--- a/sqlrustler/sqlrustler.py
+++ b/sqlrustler/sqlrustler.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Dict, List
 
 
-class DatabaseType(Enum, str):
+class DatabaseType(str, Enum):
     Postgres = "POSTGRESQL"
     MySql = "MYSQL"
     SQLite = "SQLITE"


### PR DESCRIPTION
1. Fixed missing space in __init__.py
2. Fixed str/Enum inheritance in sqlrustler.py